### PR TITLE
Add tax form rule and 1099 preference sections

### DIFF
--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -1,0 +1,72 @@
+import { FunctionComponent } from "react";
+import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const ReportingPreferences: FunctionComponent = () => {
+  return (
+    <Section>
+      <Header>
+        <Title>1099 Reporting Preferences</Title>
+      </Header>
+      <Content>
+        <CBRBSelector1
+          title="Auto-file 1099s for all eligible vendors"
+          title1="Fully automated: system tracks, generates, files, and delivers"
+        />
+        <CBRBSelector
+          title="Manual selection"
+          title1="Client reviews & selects which vendors to include at year-end"
+        />
+        <CBRBSelector
+          title="No filing (client handles it externally)"
+          title1="System provides payout summaries but does not file"
+        />
+      </Content>
+    </Section>
+  );
+};
+
+export default ReportingPreferences;

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -1,0 +1,75 @@
+import { FunctionComponent } from "react";
+import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const TaxFormCollectionRule: FunctionComponent = () => {
+  return (
+    <Section>
+      <Header>
+        <Title>Tax Form Collection Rules</Title>
+      </Header>
+      <Content>
+        <CBRBSelector1
+          title="Always collect"
+          title1="Require from all vendors upon onboarding."
+        />
+        <CBRBSelector
+          title="Trigger after $600"
+          title1="Require once total payments to a vendor ≥ $600."
+        />
+        <CBRBSelector
+          title="Include one-time payments over $600"
+        />
+        <CBRBSelector title="Block payouts until form is completed" />
+        <CBRBSelector title="Auto-email notification to vendor" />
+        <CBRBSelector title="Vendor portal warning/banner" />
+        <CBRBSelector title="Audit log per vendor" />
+      </Content>
+    </Section>
+  );
+};
+
+export default TaxFormCollectionRule;

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -6,6 +6,8 @@ import CBRBSelector from "../components/CBRBSelector";
 import CBRBSelector1 from "../components/CBRBSelector1";
 import ManuallyReview from "../components/ManuallyReview";
 import AutomaticallyApprove from "../components/AutomaticallyApprove";
+import TaxFormCollectionRule from "../components/TaxFormCollectionRule";
+import ReportingPreferences from "../components/ReportingPreferences";
 import { useNavigate } from "react-router-dom";
 
 const SidebarWizard1 = styled.div`
@@ -456,7 +458,7 @@ const Wrapping1 = styled.main`
 `;
 const ApiConnectionTaxSettingsRoot = styled.div`
   width: 100%;
-  height: 1919px;
+  height: 2300px;
   position: relative;
   background-color: var(--Tooltip-190-Tooltip-fill);
   display: flex;
@@ -597,7 +599,9 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                   </Content111>
                 </TaxFormNotRequired>
               </Content1111>
-            </TaxFormSectionComp>
+              </TaxFormSectionComp>
+            <TaxFormCollectionRule />
+            <ReportingPreferences />
             <Separator1 />
           </Scroll>
           <ActionBtn>


### PR DESCRIPTION
## Summary
- add TaxFormCollectionRule component for vendor tax form trigger options
- add ReportingPreferences component for 1099 automation settings
- include new components in tax settings page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686157029ab88333a070596dd8cdfcd7