### PR TITLE
Add tax form rule and 1099 preference sections

### DIFF
--- a/src/components/CBRBSelector.tsx
+++ b/src/components/CBRBSelector.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, type CSSProperties } from "react";
+import {
+  FunctionComponent,
+  type CSSProperties,
+  type InputHTMLAttributes,
+} from "react";
 import styled from "styled-components";
 
 export type CBRBSelectorType = {
@@ -9,6 +13,9 @@ export type CBRBSelectorType = {
   /** Style props */
   rBAlignItems?: CSSProperties["alignItems"];
   titleMinWidth?: CSSProperties["minWidth"];
+
+  /** Props forwarded to the underlying input element */
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
 };
 
 const Shape1 = styled.input`
@@ -81,11 +88,12 @@ const CBRBSelector: FunctionComponent<CBRBSelectorType> = ({
   titleMinWidth,
   title,
   title1,
+  inputProps,
 }) => {
   return (
     <CbRbSelectorRoot className={className}>
       <Rb rBAlignItems={rBAlignItems}>
-        <Shape1 type="radio" />
+        <Shape1 type="radio" {...inputProps} />
         <Title111 titleMinWidth={titleMinWidth}>
           <Title1>{title}</Title1>
           <Title11>{title1}</Title11>

--- a/src/components/CBRBSelector1.tsx
+++ b/src/components/CBRBSelector1.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, type CSSProperties } from "react";
+import {
+  FunctionComponent,
+  type CSSProperties,
+  type InputHTMLAttributes,
+} from "react";
 import styled from "styled-components";
 
 export type CBRBSelector1Type = {
@@ -9,6 +13,9 @@ export type CBRBSelector1Type = {
   /** Style props */
   rBAlignItems?: CSSProperties["alignItems"];
   titleMinWidth?: CSSProperties["minWidth"];
+
+  /** Props forwarded to the underlying input element */
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
 };
 
 const Shape1 = styled.input`
@@ -86,11 +93,12 @@ const CBRBSelector1: FunctionComponent<CBRBSelector1Type> = ({
   titleMinWidth,
   title,
   title1,
+  inputProps,
 }) => {
   return (
     <CbRbSelectorRoot className={className}>
       <Rb rBAlignItems={rBAlignItems}>
-        <Shape1 type="radio" />
+        <Shape1 type="radio" {...inputProps} />
         <Title111 titleMinWidth={titleMinWidth}>
           <Title1>{title}</Title1>
           <Title11>{title1}</Title11>

--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -1,0 +1,123 @@
+import { FunctionComponent, useState } from "react";
+import styled from "styled-components";
+
+export type ReportingPreferenceOption = "auto" | "manual" | "none";
+
+export interface ReportingPreferenceState {
+  preference: ReportingPreferenceOption;
+}
+
+export interface ReportingPreferencesProps {
+  onChange?: (state: ReportingPreferenceState) => void;
+}
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const Row = styled.label`
+  display: flex;
+  align-items: center;
+  gap: var(--gap-8);
+`;
+
+const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
+  onChange,
+}) => {
+  const [state, setState] = useState<ReportingPreferenceState>({
+    preference: "auto",
+  });
+
+  const change = (value: ReportingPreferenceOption) => {
+    const newState = { preference: value };
+    setState(newState);
+    onChange?.(newState);
+  };
+
+  return (
+    <Section>
+      <Header>
+        <Title>1099 Reporting Preferences</Title>
+      </Header>
+      <Content>
+        <Row>
+          <input
+            type="radio"
+            name="reporting"
+            value="auto"
+            checked={state.preference === "auto"}
+            onChange={() => change("auto")}
+          />
+          <span>
+            Auto-file 1099s for all eligible vendors – fully automated tracking,
+            filing and delivery.
+          </span>
+        </Row>
+        <Row>
+          <input
+            type="radio"
+            name="reporting"
+            value="manual"
+            checked={state.preference === "manual"}
+            onChange={() => change("manual")}
+          />
+          <span>
+            Manual selection – review and choose vendors to include at year-end
+          </span>
+        </Row>
+        <Row>
+          <input
+            type="radio"
+            name="reporting"
+            value="none"
+            checked={state.preference === "none"}
+            onChange={() => change("none")}
+          />
+          <span>
+            No filing – you handle 1099s externally; payout summaries only
+          </span>
+        </Row>
+      </Content>
+    </Section>
+  );
+};
+
+export default ReportingPreferences;

--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -1,5 +1,7 @@
 import { FunctionComponent, useState } from "react";
 import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
 
 export type ReportingPreferenceOption = "auto" | "manual" | "none";
 
@@ -53,11 +55,6 @@ const Content = styled.div`
   gap: var(--gap-8);
 `;
 
-const Row = styled.label`
-  display: flex;
-  align-items: center;
-  gap: var(--gap-8);
-`;
 
 const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
   onChange,
@@ -72,52 +69,52 @@ const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
     onChange?.(newState);
   };
 
+  const renderOption = (
+    value: ReportingPreferenceOption,
+    title: string,
+    subtitle: string,
+    testId: string,
+  ) => {
+    const Selected = state.preference === value ? CBRBSelector1 : CBRBSelector;
+    return (
+      <Selected
+        title={title}
+        title1={subtitle}
+        inputProps={{
+          name: "reporting",
+          value,
+          checked: state.preference === value,
+          onChange: () => change(value),
+          "data-testid": testId,
+        }}
+      />
+    );
+  };
+
   return (
     <Section data-testid="reporting-preferences">
       <Header>
         <Title>1099 Reporting Preferences</Title>
       </Header>
       <Content>
-        <Row>
-          <input
-            type="radio"
-            name="reporting"
-            value="auto"
-            checked={state.preference === "auto"}
-            onChange={() => change("auto")}
-            data-testid="reporting-auto"
-          />
-          <span>
-            Auto-file 1099s for all eligible vendors – fully automated tracking,
-            filing and delivery.
-          </span>
-        </Row>
-        <Row>
-          <input
-            type="radio"
-            name="reporting"
-            value="manual"
-            checked={state.preference === "manual"}
-            onChange={() => change("manual")}
-            data-testid="reporting-manual"
-          />
-          <span>
-            Manual selection – review and choose vendors to include at year-end
-          </span>
-        </Row>
-        <Row>
-          <input
-            type="radio"
-            name="reporting"
-            value="none"
-            checked={state.preference === "none"}
-            onChange={() => change("none")}
-            data-testid="reporting-none"
-          />
-          <span>
-            No filing – you handle 1099s externally; payout summaries only
-          </span>
-        </Row>
+        {renderOption(
+          "auto",
+          "Auto-file 1099s for all eligible vendors",
+          "Fully automated: system tracks, generates, files, and delivers",
+          "reporting-auto",
+        )}
+        {renderOption(
+          "manual",
+          "Manual selection",
+          "Client reviews & selects which vendors to include at year-end",
+          "reporting-manual",
+        )}
+        {renderOption(
+          "none",
+          "No filing (client handles it externally)",
+          "System provides payout summaries but does not file",
+          "reporting-none",
+        )}
       </Content>
     </Section>
   );

--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -55,7 +55,6 @@ const Content = styled.div`
   gap: var(--gap-8);
 `;
 
-
 const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
   onChange,
 }) => {

--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -73,7 +73,7 @@ const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
   };
 
   return (
-    <Section>
+    <Section data-testid="reporting-preferences">
       <Header>
         <Title>1099 Reporting Preferences</Title>
       </Header>
@@ -85,6 +85,7 @@ const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
             value="auto"
             checked={state.preference === "auto"}
             onChange={() => change("auto")}
+            data-testid="reporting-auto"
           />
           <span>
             Auto-file 1099s for all eligible vendors – fully automated tracking,
@@ -98,6 +99,7 @@ const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
             value="manual"
             checked={state.preference === "manual"}
             onChange={() => change("manual")}
+            data-testid="reporting-manual"
           />
           <span>
             Manual selection – review and choose vendors to include at year-end
@@ -110,6 +112,7 @@ const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
             value="none"
             checked={state.preference === "none"}
             onChange={() => change("none")}
+            data-testid="reporting-none"
           />
           <span>
             No filing – you handle 1099s externally; payout summaries only

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent, useState, ChangeEvent } from "react";
 import styled from "styled-components";
 
 export type RuleOption = "always" | "threshold";
@@ -96,7 +96,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
   const handleBooleanChange = (
     key: keyof Omit<TaxFormCollectionRuleState, "rule">
   ) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       update({ ...state, [key]: e.target.checked });
     };
 

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -1,5 +1,7 @@
 import { FunctionComponent, useState, ChangeEvent } from "react";
 import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
 
 export type RuleOption = "always" | "threshold";
 
@@ -58,11 +60,6 @@ const Content = styled.div`
   gap: var(--gap-8);
 `;
 
-const Row = styled.label`
-  display: flex;
-  align-items: center;
-  gap: var(--gap-8);
-`;
 
 const SubOptions = styled.div`
   display: flex;
@@ -100,36 +97,38 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
       update({ ...state, [key]: e.target.checked });
     };
 
+  const renderRadioOption = (value: RuleOption, label: string, testId: string) => {
+    const Selected = state.rule === value ? CBRBSelector1 : CBRBSelector;
+    return (
+      <Selected
+        title={label}
+        inputProps={{
+          name: "tax-rule",
+          value,
+          checked: state.rule === value,
+          onChange: () => handleRuleChange(value),
+          "data-testid": testId,
+        }}
+      />
+    );
+  };
+
   return (
     <Section data-testid="tax-form-rule">
       <Header>
         <Title>Tax Form Collection Rules</Title>
       </Header>
       <Content>
-        <Row>
-          <input
-            type="radio"
-            name="tax-rule"
-            value="always"
-            checked={state.rule === "always"}
-            onChange={() => handleRuleChange("always")}
-            data-testid="rule-always"
-          />
-          <span>Always collect – Require from all vendors upon onboarding.</span>
-        </Row>
-        <Row>
-          <input
-            type="radio"
-            name="tax-rule"
-            value="threshold"
-            checked={state.rule === "threshold"}
-            onChange={() => handleRuleChange("threshold")}
-            data-testid="rule-threshold"
-          />
-          <span>
-            Trigger after $600 – Require once total payments to a vendor ≥ $600.
-          </span>
-        </Row>
+        {renderRadioOption(
+          "always",
+          "Always collect – Require from all vendors upon onboarding.",
+          "rule-always",
+        )}
+        {renderRadioOption(
+          "threshold",
+          "Trigger after $600 – Require once total payments to a vendor ≥ $600.",
+          "rule-threshold",
+        )}
         {state.rule === "threshold" && (
           <SubOptions>
             <label>

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -60,7 +60,6 @@ const Content = styled.div`
   gap: var(--gap-8);
 `;
 
-
 const SubOptions = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -1,0 +1,180 @@
+import { FunctionComponent, useState } from "react";
+import styled from "styled-components";
+
+export type RuleOption = "always" | "threshold";
+
+export interface TaxFormCollectionRuleState {
+  rule: RuleOption;
+  includeOneTime: boolean;
+  blockPayouts: boolean;
+  autoEmail: boolean;
+  portalBanner: boolean;
+  auditLog: boolean;
+}
+
+export interface TaxFormCollectionRuleProps {
+  onChange?: (state: TaxFormCollectionRuleState) => void;
+}
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const Row = styled.label`
+  display: flex;
+  align-items: center;
+  gap: var(--gap-8);
+`;
+
+const SubOptions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--gap-8);
+  margin-left: 24px;
+`;
+
+const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
+  onChange,
+}) => {
+  const [state, setState] = useState<TaxFormCollectionRuleState>({
+    rule: "always",
+    includeOneTime: true,
+    blockPayouts: true,
+    autoEmail: true,
+    portalBanner: true,
+    auditLog: true,
+  });
+
+  const update = (newState: TaxFormCollectionRuleState) => {
+    setState(newState);
+    onChange?.(newState);
+  };
+
+  const handleRuleChange = (value: RuleOption) => {
+    update({ ...state, rule: value });
+  };
+
+  const handleBooleanChange = (
+    key: keyof Omit<TaxFormCollectionRuleState, "rule">
+  ) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      update({ ...state, [key]: e.target.checked });
+    };
+
+  return (
+    <Section>
+      <Header>
+        <Title>Tax Form Collection Rules</Title>
+      </Header>
+      <Content>
+        <Row>
+          <input
+            type="radio"
+            name="tax-rule"
+            value="always"
+            checked={state.rule === "always"}
+            onChange={() => handleRuleChange("always")}
+          />
+          <span>Always collect – Require from all vendors upon onboarding.</span>
+        </Row>
+        <Row>
+          <input
+            type="radio"
+            name="tax-rule"
+            value="threshold"
+            checked={state.rule === "threshold"}
+            onChange={() => handleRuleChange("threshold")}
+          />
+          <span>
+            Trigger after $600 – Require once total payments to a vendor ≥ $600.
+          </span>
+        </Row>
+        {state.rule === "threshold" && (
+          <SubOptions>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.includeOneTime}
+                onChange={handleBooleanChange("includeOneTime")}
+              />
+              Include one-time payments over $600
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.blockPayouts}
+                onChange={handleBooleanChange("blockPayouts")}
+              />
+              Block payouts until form is completed
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.autoEmail}
+                onChange={handleBooleanChange("autoEmail")}
+              />
+              Auto-email notification to vendor
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.portalBanner}
+                onChange={handleBooleanChange("portalBanner")}
+              />
+              Vendor portal warning/banner
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.auditLog}
+                onChange={handleBooleanChange("auditLog")}
+              />
+              Audit log per vendor
+            </label>
+          </SubOptions>
+        )}
+      </Content>
+    </Section>
+  );
+};
+
+export default TaxFormCollectionRule;

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -101,7 +101,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
     };
 
   return (
-    <Section>
+    <Section data-testid="tax-form-rule">
       <Header>
         <Title>Tax Form Collection Rules</Title>
       </Header>
@@ -113,6 +113,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
             value="always"
             checked={state.rule === "always"}
             onChange={() => handleRuleChange("always")}
+            data-testid="rule-always"
           />
           <span>Always collect – Require from all vendors upon onboarding.</span>
         </Row>
@@ -123,6 +124,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
             value="threshold"
             checked={state.rule === "threshold"}
             onChange={() => handleRuleChange("threshold")}
+            data-testid="rule-threshold"
           />
           <span>
             Trigger after $600 – Require once total payments to a vendor ≥ $600.
@@ -135,6 +137,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
                 type="checkbox"
                 checked={state.includeOneTime}
                 onChange={handleBooleanChange("includeOneTime")}
+                data-testid="rule-include-one-time"
               />
               Include one-time payments over $600
             </label>
@@ -143,6 +146,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
                 type="checkbox"
                 checked={state.blockPayouts}
                 onChange={handleBooleanChange("blockPayouts")}
+                data-testid="rule-block-payouts"
               />
               Block payouts until form is completed
             </label>
@@ -151,6 +155,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
                 type="checkbox"
                 checked={state.autoEmail}
                 onChange={handleBooleanChange("autoEmail")}
+                data-testid="rule-auto-email"
               />
               Auto-email notification to vendor
             </label>
@@ -159,6 +164,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
                 type="checkbox"
                 checked={state.portalBanner}
                 onChange={handleBooleanChange("portalBanner")}
+                data-testid="rule-portal-banner"
               />
               Vendor portal warning/banner
             </label>
@@ -167,6 +173,7 @@ const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
                 type="checkbox"
                 checked={state.auditLog}
                 onChange={handleBooleanChange("auditLog")}
+                data-testid="rule-audit-log"
               />
               Audit log per vendor
             </label>

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -600,8 +600,8 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                 </TaxFormNotRequired>
               </Content1111>
               </TaxFormSectionComp>
-            <TaxFormCollectionRule onChange={(s) => console.log("tax rule", s)} />
-            <ReportingPreferences onChange={(s) => console.log("reporting", s)} />
+            <TaxFormCollectionRule />
+            <ReportingPreferences />
             <Separator1 />
           </Scroll>
           <ActionBtn>

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -6,6 +6,8 @@ import CBRBSelector from "../components/CBRBSelector";
 import CBRBSelector1 from "../components/CBRBSelector1";
 import ManuallyReview from "../components/ManuallyReview";
 import AutomaticallyApprove from "../components/AutomaticallyApprove";
+import TaxFormCollectionRule from "../components/TaxFormCollectionRule";
+import ReportingPreferences from "../components/ReportingPreferences";
 import { useNavigate } from "react-router-dom";
 
 const SidebarWizard1 = styled.div`
@@ -456,7 +458,7 @@ const Wrapping1 = styled.main`
 `;
 const ApiConnectionTaxSettingsRoot = styled.div`
   width: 100%;
-  height: 1919px;
+  height: 2300px;
   position: relative;
   background-color: var(--Tooltip-190-Tooltip-fill);
   display: flex;
@@ -597,7 +599,9 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                   </Content111>
                 </TaxFormNotRequired>
               </Content1111>
-            </TaxFormSectionComp>
+              </TaxFormSectionComp>
+            <TaxFormCollectionRule onChange={(s) => console.log("tax rule", s)} />
+            <ReportingPreferences onChange={(s) => console.log("reporting", s)} />
             <Separator1 />
           </Scroll>
           <ActionBtn>

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -606,6 +606,7 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
             <ReportingPreferences
               onChange={(state) => console.log("reporting", state)}
             />
+
             <Separator1 />
           </Scroll>
           <ActionBtn>

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -600,12 +600,8 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                 </TaxFormNotRequired>
               </Content1111>
               </TaxFormSectionComp>
-            <TaxFormCollectionRule
-              onChange={(state) => console.log("tax rule", state)}
-            />
-            <ReportingPreferences
-              onChange={(state) => console.log("reporting", state)}
-            />
+            <TaxFormCollectionRule />
+            <ReportingPreferences />
 
             <Separator1 />
           </Scroll>

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -600,8 +600,12 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                 </TaxFormNotRequired>
               </Content1111>
               </TaxFormSectionComp>
-            <TaxFormCollectionRule />
-            <ReportingPreferences />
+            <TaxFormCollectionRule
+              onChange={(state) => console.log("tax rule", state)}
+            />
+            <ReportingPreferences
+              onChange={(state) => console.log("reporting", state)}
+            />
             <Separator1 />
           </Scroll>
           <ActionBtn>


### PR DESCRIPTION
## Summary
- add TaxFormCollectionRule component for vendor tax form trigger options
- add ReportingPreferences component for 1099 automation settings
- include new components in tax settings page
- make dynamic with radio/checkbox options and callback hooks

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686157029ab88333a070596dd8cdfcd7