### PR TITLE
Add tax form rule and reporting prefs UI

### DIFF
--- a/src/components/CBRBSelector.tsx
+++ b/src/components/CBRBSelector.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, type CSSProperties } from "react";
+import {
+  FunctionComponent,
+  type CSSProperties,
+  type InputHTMLAttributes,
+} from "react";
 import styled from "styled-components";
 
 export type CBRBSelectorType = {
@@ -9,6 +13,9 @@ export type CBRBSelectorType = {
   /** Style props */
   rBAlignItems?: CSSProperties["alignItems"];
   titleMinWidth?: CSSProperties["minWidth"];
+
+  /** Props forwarded to the underlying input element */
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
 };
 
 const Shape1 = styled.input`
@@ -58,7 +65,7 @@ const Rb = styled.div<{ rBAlignItems?: CSSProperties["alignItems"] }>`
   }
   align-items: ${(p) => p.rBAlignItems};
 `;
-const CbRbSelectorRoot = styled.div`
+const CbRbSelectorRoot = styled.label`
   align-self: stretch;
   border-radius: var(--Radius-CB-RB-bgselector);
   background-color: var(--Default-310-Fill);
@@ -73,6 +80,7 @@ const CbRbSelectorRoot = styled.div`
   font-size: var(--Paragraph-14-Paragraph-bold-Font-Size);
   color: var(--Default-310-Title);
   font-family: var(--Inter);
+  cursor: pointer;
 `;
 
 const CBRBSelector: FunctionComponent<CBRBSelectorType> = ({
@@ -81,11 +89,12 @@ const CBRBSelector: FunctionComponent<CBRBSelectorType> = ({
   titleMinWidth,
   title,
   title1,
+  inputProps,
 }) => {
   return (
     <CbRbSelectorRoot className={className}>
       <Rb rBAlignItems={rBAlignItems}>
-        <Shape1 type="radio" />
+        <Shape1 type="radio" {...inputProps} />
         <Title111 titleMinWidth={titleMinWidth}>
           <Title1>{title}</Title1>
           <Title11>{title1}</Title11>

--- a/src/components/CBRBSelector1.tsx
+++ b/src/components/CBRBSelector1.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, type CSSProperties } from "react";
+import {
+  FunctionComponent,
+  type CSSProperties,
+  type InputHTMLAttributes,
+} from "react";
 import styled from "styled-components";
 
 export type CBRBSelector1Type = {
@@ -9,6 +13,9 @@ export type CBRBSelector1Type = {
   /** Style props */
   rBAlignItems?: CSSProperties["alignItems"];
   titleMinWidth?: CSSProperties["minWidth"];
+
+  /** Props forwarded to the underlying input element */
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
 };
 
 const Shape1 = styled.input`
@@ -62,7 +69,7 @@ const Rb = styled.div<{ rBAlignItems?: CSSProperties["alignItems"] }>`
   }
   align-items: ${(p) => p.rBAlignItems};
 `;
-const CbRbSelectorRoot = styled.div`
+const CbRbSelectorRoot = styled.label`
   align-self: stretch;
   border-radius: var(--Radius-CB-RB-bgselector);
   background-color: var(--Active-Checked-Undertemined-310-Fill);
@@ -78,6 +85,7 @@ const CbRbSelectorRoot = styled.div`
   font-size: var(--Paragraph-14-Paragraph-bold-Font-Size);
   color: var(--Active-Checked-Undertemined-310-Title);
   font-family: var(--Inter);
+  cursor: pointer;
 `;
 
 const CBRBSelector1: FunctionComponent<CBRBSelector1Type> = ({
@@ -86,11 +94,12 @@ const CBRBSelector1: FunctionComponent<CBRBSelector1Type> = ({
   titleMinWidth,
   title,
   title1,
+  inputProps,
 }) => {
   return (
     <CbRbSelectorRoot className={className}>
       <Rb rBAlignItems={rBAlignItems}>
-        <Shape1 type="radio" />
+        <Shape1 type="radio" {...inputProps} />
         <Title111 titleMinWidth={titleMinWidth}>
           <Title1>{title}</Title1>
           <Title11>{title1}</Title11>

--- a/src/components/ReportingPreferences.tsx
+++ b/src/components/ReportingPreferences.tsx
@@ -1,0 +1,122 @@
+import { FunctionComponent, useState } from "react";
+import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
+
+export type ReportingPreferenceOption = "auto" | "manual" | "none";
+
+export interface ReportingPreferenceState {
+  preference: ReportingPreferenceOption;
+}
+
+export interface ReportingPreferencesProps {
+  onChange?: (state: ReportingPreferenceState) => void;
+}
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const ReportingPreferences: FunctionComponent<ReportingPreferencesProps> = ({
+  onChange,
+}) => {
+  const [state, setState] = useState<ReportingPreferenceState>({
+    preference: "auto",
+  });
+
+  const change = (value: ReportingPreferenceOption) => {
+    const newState = { preference: value };
+    setState(newState);
+    onChange?.(newState);
+  };
+
+  const renderOption = (
+    value: ReportingPreferenceOption,
+    title: string,
+    subtitle: string,
+    testId: string,
+  ) => {
+    const Selected = state.preference === value ? CBRBSelector1 : CBRBSelector;
+    return (
+      <Selected
+        title={title}
+        title1={subtitle}
+        inputProps={{
+          name: "reporting",
+          value,
+          checked: state.preference === value,
+          onChange: () => change(value),
+          "data-testid": testId,
+        }}
+      />
+    );
+  };
+
+  return (
+    <Section data-testid="reporting-preferences">
+      <Header>
+        <Title>1099 Reporting Preferences</Title>
+      </Header>
+      <Content>
+        {renderOption(
+          "auto",
+          "Auto-file 1099s for all eligible vendors",
+          "Fully automated: system tracks, generates, files, and delivers",
+          "reporting-auto",
+        )}
+        {renderOption(
+          "manual",
+          "Manual selection",
+          "Client reviews & selects which vendors to include at year-end",
+          "reporting-manual",
+        )}
+        {renderOption(
+          "none",
+          "No filing (client handles it externally)",
+          "System provides payout summaries but does not file",
+          "reporting-none",
+        )}
+      </Content>
+    </Section>
+  );
+};
+
+export default ReportingPreferences;

--- a/src/components/TaxFormCollectionRule.tsx
+++ b/src/components/TaxFormCollectionRule.tsx
@@ -1,0 +1,185 @@
+import { FunctionComponent, useState, ChangeEvent } from "react";
+import styled from "styled-components";
+import CBRBSelector from "./CBRBSelector";
+import CBRBSelector1 from "./CBRBSelector1";
+
+export type RuleOption = "always" | "threshold";
+
+export interface TaxFormCollectionRuleState {
+  rule: RuleOption;
+  includeOneTime: boolean;
+  blockPayouts: boolean;
+  autoEmail: boolean;
+  portalBanner: boolean;
+  auditLog: boolean;
+}
+
+export interface TaxFormCollectionRuleProps {
+  onChange?: (state: TaxFormCollectionRuleState) => void;
+}
+
+const Section = styled.section`
+  align-self: stretch;
+  border-radius: var(--br-12);
+  background-color: var(--Tooltip-190-Tooltip-fill);
+  border: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: var(--Headline-16-Headline-bold-Font-Size);
+  color: var(--Default-290-Text);
+  font-family: var(--Inter);
+`;
+
+const Header = styled.div`
+  align-self: stretch;
+  border-bottom: 1px solid var(--Disabled-Default-310-CB-RB-stroke);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--padding-12) var(--padding-24) var(--padding-10);
+  gap: var(--gap-8);
+`;
+
+const Title = styled.b`
+  flex: 1;
+  position: relative;
+  line-height: var(--Headline-16-Headline-bold-Font-Line-Height);
+`;
+
+const Content = styled.div`
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--padding-24);
+  gap: var(--gap-8);
+`;
+
+const SubOptions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--gap-8);
+  margin-left: 24px;
+`;
+
+const TaxFormCollectionRule: FunctionComponent<TaxFormCollectionRuleProps> = ({
+  onChange,
+}) => {
+  const [state, setState] = useState<TaxFormCollectionRuleState>({
+    rule: "always",
+    includeOneTime: true,
+    blockPayouts: true,
+    autoEmail: true,
+    portalBanner: true,
+    auditLog: true,
+  });
+
+  const update = (newState: TaxFormCollectionRuleState) => {
+    setState(newState);
+    onChange?.(newState);
+  };
+
+  const handleRuleChange = (value: RuleOption) => {
+    update({ ...state, rule: value });
+  };
+
+  const handleBooleanChange = (
+    key: keyof Omit<TaxFormCollectionRuleState, "rule">
+  ) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      update({ ...state, [key]: e.target.checked });
+    };
+
+  const renderRadioOption = (value: RuleOption, label: string, testId: string) => {
+    const Selected = state.rule === value ? CBRBSelector1 : CBRBSelector;
+    return (
+      <Selected
+        title={label}
+        inputProps={{
+          name: "tax-rule",
+          value,
+          checked: state.rule === value,
+          onChange: () => handleRuleChange(value),
+          "data-testid": testId,
+        }}
+      />
+    );
+  };
+
+  return (
+    <Section data-testid="tax-form-rule">
+      <Header>
+        <Title>Tax Form Collection Rules</Title>
+      </Header>
+      <Content>
+        {renderRadioOption(
+          "always",
+          "Always collect – Require from all vendors upon onboarding.",
+          "rule-always",
+        )}
+        {renderRadioOption(
+          "threshold",
+          "Trigger after $600 – Require once total payments to a vendor ≥ $600.",
+          "rule-threshold",
+        )}
+        {state.rule === "threshold" && (
+          <SubOptions>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.includeOneTime}
+                onChange={handleBooleanChange("includeOneTime")}
+                data-testid="rule-include-one-time"
+              />
+              Include one-time payments over $600
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.blockPayouts}
+                onChange={handleBooleanChange("blockPayouts")}
+                data-testid="rule-block-payouts"
+              />
+              Block payouts until form is completed
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.autoEmail}
+                onChange={handleBooleanChange("autoEmail")}
+                data-testid="rule-auto-email"
+              />
+              Auto-email notification to vendor
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.portalBanner}
+                onChange={handleBooleanChange("portalBanner")}
+                data-testid="rule-portal-banner"
+              />
+              Vendor portal warning/banner
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.auditLog}
+                onChange={handleBooleanChange("auditLog")}
+                data-testid="rule-audit-log"
+              />
+              Audit log per vendor
+            </label>
+          </SubOptions>
+        )}
+      </Content>
+    </Section>
+  );
+};
+
+export default TaxFormCollectionRule;

--- a/src/pages/APIConnectionTAXSettingsEnable.tsx
+++ b/src/pages/APIConnectionTAXSettingsEnable.tsx
@@ -6,6 +6,8 @@ import CBRBSelector from "../components/CBRBSelector";
 import CBRBSelector1 from "../components/CBRBSelector1";
 import ManuallyReview from "../components/ManuallyReview";
 import AutomaticallyApprove from "../components/AutomaticallyApprove";
+import TaxFormCollectionRule from "../components/TaxFormCollectionRule";
+import ReportingPreferences from "../components/ReportingPreferences";
 import { useNavigate } from "react-router-dom";
 
 const SidebarWizard1 = styled.div`
@@ -456,7 +458,7 @@ const Wrapping1 = styled.main`
 `;
 const ApiConnectionTaxSettingsRoot = styled.div`
   width: 100%;
-  height: 1919px;
+  height: 2300px;
   position: relative;
   background-color: var(--Tooltip-190-Tooltip-fill);
   display: flex;
@@ -597,7 +599,10 @@ const APIConnectionTAXSettingsEnable: FunctionComponent = () => {
                   </Content111>
                 </TaxFormNotRequired>
               </Content1111>
-            </TaxFormSectionComp>
+              </TaxFormSectionComp>
+            <TaxFormCollectionRule />
+            <ReportingPreferences />
+
             <Separator1 />
           </Scroll>
           <ActionBtn>


### PR DESCRIPTION
## Summary
- refine custom radio selector components to accept input props
- integrate selectors in `ReportingPreferences` and `TaxFormCollectionRule`
- keep UI styling while enabling stateful behaviour with test IDs
- simplify TAX settings page now that callbacks are optional
- make custom radio selectors clickable

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686157029ab88333a070596dd8cdfcd7